### PR TITLE
APM airplane toggle & update icons

### DIFF
--- a/decompiled/android.policy.jar.out/smali/com/android/internal/policy/impl/GlobalActions.smali
+++ b/decompiled/android.policy.jar.out/smali/com/android/internal/policy/impl/GlobalActions.smali
@@ -911,6 +911,12 @@
 
     iget-object v0, p0, Lcom/android/internal/policy/impl/GlobalActions;->mItems:Ljava/util/ArrayList;
 
+    iget-object v1, p0, Lcom/android/internal/policy/impl/GlobalActions;->mAirplaneModeOn:Lcom/android/internal/policy/impl/GlobalActions$ToggleAction;
+
+    invoke-virtual {v0, v1}, Ljava/util/ArrayList;->add(Ljava/lang/Object;)Z
+
+    iget-object v0, p0, Lcom/android/internal/policy/impl/GlobalActions;->mItems:Ljava/util/ArrayList;
+
     iget-object v1, p0, Lcom/android/internal/policy/impl/GlobalActions;->mSilentModeAction:Lcom/android/internal/policy/impl/GlobalActions$Action;
 
     invoke-virtual {v0, v1}, Ljava/util/ArrayList;->add(Ljava/lang/Object;)Z
@@ -922,23 +928,6 @@
     goto :goto_2
 
     :cond_3
-    const-string v0, "airplane"
-
-    invoke-virtual {v0, v7}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
-
-    move-result v0
-
-    if-eqz v0, :cond_4
-
-    iget-object v0, p0, Lcom/android/internal/policy/impl/GlobalActions;->mItems:Ljava/util/ArrayList;
-
-    iget-object v1, p0, Lcom/android/internal/policy/impl/GlobalActions;->mAirplaneModeOn:Lcom/android/internal/policy/impl/GlobalActions$ToggleAction;
-
-    invoke-virtual {v0, v1}, Ljava/util/ArrayList;->add(Ljava/lang/Object;)Z
-
-    goto :goto_3
-
-    :cond_4
     const-string v0, "bugreport"
 
     invoke-virtual {v0, v7}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z


### PR DESCRIPTION
as airplane toggle changes color if on or off, all other icons should be grey (off) too.

- needs ic_audio_ring_notif.xml, ic_audio_ring_notif_mute.xml & ic_audio_ring_notif_vibrate.xml to have color #ff6d6d6d
- grey icons: https://mega.co.nz/#!EMR2CJiB!3ll7NEMVSty3oChgATuIIRPfQ86oIsrWD6BeyePW8OI

screens how it will look: http://i.imgur.com/XtiqDc7.png - http://i.imgur.com/qGS2OOt.png
airplane toggle icon will be green if enabled.